### PR TITLE
fix for team city - downgrade from .net 4.8.1 to 4.8

### DIFF
--- a/Telia.GraphQL.Client/Telia.GraphQL.Client.csproj
+++ b/Telia.GraphQL.Client/Telia.GraphQL.Client.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Telia.GraphQL.Client</RootNamespace>
     <AssemblyName>Telia.GraphQL.Client</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
team city doesn't have 4.8.1 installed.  I'm not about to try to get IT to try to install it.